### PR TITLE
make this work even with unicode names

### DIFF
--- a/podcasting/models.py
+++ b/podcasting/models.py
@@ -473,7 +473,7 @@ class Enclosure(models.Model):
         verbose_name_plural = _("Enclosures")
 
     def __str__(self):
-        return "{} - {}".format(self.episode, self.mime)
+        return u"{} - {}".format(self.episode, self.mime)
 
 
 @python_2_unicode_compatible
@@ -501,4 +501,4 @@ class EmbedMedia(models.Model):
         verbose_name_plural = _("Embed Media URLs")
 
     def __str__(self):
-        return "{} - {}".format(self.episode, self.url)
+        return u"{} - {}".format(self.episode, self.url)


### PR DESCRIPTION
If your Episode has a unicode name, then you can't create Enclosures (not even in admin). You get a unicode error, due to its **str** method doing stuff with unicode strings inside an ascii string. This patch fixes it.
