### PR TITLE
Updated Import Logic To Support Django 4

### DIFF
--- a/podcasting/admin.py
+++ b/podcasting/admin.py
@@ -1,4 +1,7 @@
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:
+    from django.utils.translation import ugettext_lazy as _
 
 from django.contrib import admin
 
@@ -7,7 +10,11 @@ try:
 except ImportError:
     AdminThumbnail = None
 
-from podcasting.forms import AdminShowForm, AdminEpisodeForm, EnclosureForm as AdminEnclosureForm
+from podcasting.forms import (
+    AdminShowForm,
+    AdminEpisodeForm,
+    EnclosureForm as AdminEnclosureForm,
+)
 from podcasting.models import Show, Episode, Enclosure, EmbedMedia
 from podcasting.utils.twitter import can_tweet
 
@@ -26,11 +33,13 @@ class ShowAdmin(admin.ModelAdmin):
 
     def published_flag(self, obj):
         return bool(obj.published)
+
     published_flag.short_description = _("Published")
     published_flag.boolean = True
 
     def show_sites(self, obj):
-        return ', '.join([site.name for site in obj.sites.all()])
+        return ", ".join([site.name for site in obj.sites.all()])
+
     show_sites.short_description = "Sites"
 
 
@@ -48,11 +57,13 @@ class EpisodeAdmin(admin.ModelAdmin):
 
     def published_flag(self, obj):
         return bool(obj.published)
+
     published_flag.short_description = _("Published")
     published_flag.boolean = True
 
     def episode_shows(self, obj):
-        return ', '.join([show.title for show in obj.shows.all()])
+        return ", ".join([show.title for show in obj.shows.all()])
+
     episode_shows.short_description = "Shows"
 
     def episode_sites(self, obj):
@@ -61,7 +72,8 @@ class EpisodeAdmin(admin.ModelAdmin):
             for site in show.sites.all():
                 if site not in sites:
                     sites.append(site)
-        return ', '.join([site.name for site in sites])
+        return ", ".join([site.name for site in sites])
+
     episode_sites.short_description = "Sites"
 
     def save_form(self, request, form, change):

--- a/podcasting/migrations/0001_initial.py
+++ b/podcasting/migrations/0001_initial.py
@@ -6,161 +6,669 @@ import autoslug.fields
 import podcasting.models
 from django.conf import settings
 import podcasting.utils.fields
-from django.utils.translation import ugettext_lazy as _
+
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:
+    from django.utils.translation import ugettext_lazy as _
 
 
 def get_license_field():
-    if 'licenses' in settings.INSTALLED_APPS:
-        license = ('license', models.ForeignKey(to='licenses.License', verbose_name=_("license")))
+    if "licenses" in settings.INSTALLED_APPS:
+        license = (
+            "license",
+            models.ForeignKey(to="licenses.License", verbose_name=_("license")),
+        )
     else:
-        license = ('license', models.CharField(
-           max_length=255,
-           help_text=_("To publish a podcast to iTunes it is required to set a license type."))
+        license = (
+            "license",
+            models.CharField(
+                max_length=255,
+                help_text=_(
+                    "To publish a podcast to iTunes it is required to set a license type."
+                ),
+            ),
         )
     return license
 
 
 def get_original_image_field():
-    if 'photologue' in settings.INSTALLED_APPS:
-        original_image = ('original_image', models.ForeignKey(to='photologue.Photo', verbose_name=_("image"), default=None, null=True, blank=True, on_delete=models.SET_NULL,help_text='\n            A podcast must have 1400 x 1400 pixel cover art in JPG or PNG\n            format using RGB color space. See our technical spec for\n            details. To be eligible for featuring on iTunes Stores,\n            choose an attractive, original, and square JPEG (.jpg) or\n            PNG (.png) image at a size of 1400x1400 pixels. The image\n            will be scaled down to 50x50 pixels at smallest in iTunes.\n            For reference see the <a\n            href="http://www.apple.com/itunes/podcasts/specs.html#metadata">iTunes\n            Podcast specs</a>.<br /><br /> For episode artwork to\n            display in iTunes, image must be <a\n            href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n            saved to file\'s <strong>metadata</strong></a> before\n            enclosure uploading!'))
+    if "photologue" in settings.INSTALLED_APPS:
+        original_image = (
+            "original_image",
+            models.ForeignKey(
+                to="photologue.Photo",
+                verbose_name=_("image"),
+                default=None,
+                null=True,
+                blank=True,
+                on_delete=models.SET_NULL,
+                help_text='\n            A podcast must have 1400 x 1400 pixel cover art in JPG or PNG\n            format using RGB color space. See our technical spec for\n            details. To be eligible for featuring on iTunes Stores,\n            choose an attractive, original, and square JPEG (.jpg) or\n            PNG (.png) image at a size of 1400x1400 pixels. The image\n            will be scaled down to 50x50 pixels at smallest in iTunes.\n            For reference see the <a\n            href="http://www.apple.com/itunes/podcasts/specs.html#metadata">iTunes\n            Podcast specs</a>.<br /><br /> For episode artwork to\n            display in iTunes, image must be <a\n            href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n            saved to file\'s <strong>metadata</strong></a> before\n            enclosure uploading!',
+            ),
+        )
     else:
-        original_image = ('original_image', models.ImageField(help_text='\n            A podcast must have 1400 x 1400 pixel cover art in JPG or PNG\n            format using RGB color space. See our technical spec for\n            details. To be eligible for featuring on iTunes Stores,\n            choose an attractive, original, and square JPEG (.jpg) or\n            PNG (.png) image at a size of 1400x1400 pixels. The image\n            will be scaled down to 50x50 pixels at smallest in iTunes.\n            For reference see the <a\n            href="http://www.apple.com/itunes/podcasts/specs.html#metadata">iTunes\n            Podcast specs</a>.<br /><br /> For episode artwork to\n            display in iTunes, image must be <a\n            href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n            saved to file\'s <strong>metadata</strong></a> before\n            enclosure uploading!', upload_to=podcasting.models.get_episode_upload_folder, verbose_name='image', blank=True))
+        original_image = (
+            "original_image",
+            models.ImageField(
+                help_text='\n            A podcast must have 1400 x 1400 pixel cover art in JPG or PNG\n            format using RGB color space. See our technical spec for\n            details. To be eligible for featuring on iTunes Stores,\n            choose an attractive, original, and square JPEG (.jpg) or\n            PNG (.png) image at a size of 1400x1400 pixels. The image\n            will be scaled down to 50x50 pixels at smallest in iTunes.\n            For reference see the <a\n            href="http://www.apple.com/itunes/podcasts/specs.html#metadata">iTunes\n            Podcast specs</a>.<br /><br /> For episode artwork to\n            display in iTunes, image must be <a\n            href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n            saved to file\'s <strong>metadata</strong></a> before\n            enclosure uploading!',
+                upload_to=podcasting.models.get_episode_upload_folder,
+                verbose_name="image",
+                blank=True,
+            ),
+        )
     return original_image
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('sites', '0001_initial'),
+        ("sites", "0001_initial"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='EmbedMedia',
+            name="EmbedMedia",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('url', models.URLField(help_text='URL of the media file', verbose_name='url')),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "url",
+                    models.URLField(
+                        help_text="URL of the media file", verbose_name="url"
+                    ),
+                ),
             ],
             options={
-                'ordering': ('episode', 'url'),
-                'verbose_name': 'Embed Media URL',
-                'verbose_name_plural': 'Embed Media URLs',
+                "ordering": ("episode", "url"),
+                "verbose_name": "Embed Media URL",
+                "verbose_name_plural": "Embed Media URLs",
             },
             bases=(models.Model,),
         ),
         migrations.CreateModel(
-            name='Enclosure',
+            name="Enclosure",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('url', models.URLField(help_text='URL of the media file. <br /> It is <strong>very</strong>\n            important to remember that for episode artwork to display in iTunes, image must be\n            <a href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n            saved to file\'s <strong>metadata</strong></a> before enclosure uploading!<br /><br />\n            For best results, choose an attractive, original, and square JPEG (.jpg) or PNG (.png)\n            image at a size of 1400x1400 pixels. The image will be\n            scaled down to 50x50 pixels at smallest in iTunes.', verbose_name='url')),
-                ('size', models.PositiveIntegerField(help_text='The length attribute is the file size in bytes. Find this information in the files properties (on a Mac, ``Get Info`` and refer to the size row)', verbose_name='size')),
-                ('mime', models.CharField(help_text='Supports mime types of: aiff, flac, mp3, mp4, ogg, flac, wav', max_length=4, verbose_name='mime format', choices=[('aiff', 'audio/aiff'), ('flac', 'audio/flac'), ('mp3', 'audio/mpeg'), ('mp4', 'audio/mp4'), ('ogg', 'audio/ogg'), ('flac', 'audio/flac'), ('wav', 'audio/wav')])),
-                ('bitrate', models.CharField(default='192', help_text='Measured in kilobits per second (kbps), often 128 or 192.', max_length=5, verbose_name='bit rate')),
-                ('sample', models.CharField(default='44.1', help_text='Measured in kilohertz (kHz), often 44.1.', max_length=5, verbose_name='sample rate')),
-                ('channel', models.CharField(default=2, help_text='Number of channels; 2 for stereo, 1 for mono.', max_length=1, verbose_name='channel')),
-                ('duration', models.IntegerField(help_text='Duration of the audio file, in seconds (always as integer).', max_length=1, verbose_name='duration')),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "url",
+                    models.URLField(
+                        help_text='URL of the media file. <br /> It is <strong>very</strong>\n            important to remember that for episode artwork to display in iTunes, image must be\n            <a href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n            saved to file\'s <strong>metadata</strong></a> before enclosure uploading!<br /><br />\n            For best results, choose an attractive, original, and square JPEG (.jpg) or PNG (.png)\n            image at a size of 1400x1400 pixels. The image will be\n            scaled down to 50x50 pixels at smallest in iTunes.',
+                        verbose_name="url",
+                    ),
+                ),
+                (
+                    "size",
+                    models.PositiveIntegerField(
+                        help_text="The length attribute is the file size in bytes. Find this information in the files properties (on a Mac, ``Get Info`` and refer to the size row)",
+                        verbose_name="size",
+                    ),
+                ),
+                (
+                    "mime",
+                    models.CharField(
+                        help_text="Supports mime types of: aiff, flac, mp3, mp4, ogg, flac, wav",
+                        max_length=4,
+                        verbose_name="mime format",
+                        choices=[
+                            ("aiff", "audio/aiff"),
+                            ("flac", "audio/flac"),
+                            ("mp3", "audio/mpeg"),
+                            ("mp4", "audio/mp4"),
+                            ("ogg", "audio/ogg"),
+                            ("flac", "audio/flac"),
+                            ("wav", "audio/wav"),
+                        ],
+                    ),
+                ),
+                (
+                    "bitrate",
+                    models.CharField(
+                        default="192",
+                        help_text="Measured in kilobits per second (kbps), often 128 or 192.",
+                        max_length=5,
+                        verbose_name="bit rate",
+                    ),
+                ),
+                (
+                    "sample",
+                    models.CharField(
+                        default="44.1",
+                        help_text="Measured in kilohertz (kHz), often 44.1.",
+                        max_length=5,
+                        verbose_name="sample rate",
+                    ),
+                ),
+                (
+                    "channel",
+                    models.CharField(
+                        default=2,
+                        help_text="Number of channels; 2 for stereo, 1 for mono.",
+                        max_length=1,
+                        verbose_name="channel",
+                    ),
+                ),
+                (
+                    "duration",
+                    models.IntegerField(
+                        help_text="Duration of the audio file, in seconds (always as integer).",
+                        max_length=1,
+                        verbose_name="duration",
+                    ),
+                ),
             ],
             options={
-                'ordering': ('episode', 'mime'),
-                'verbose_name': 'Enclosure',
-                'verbose_name_plural': 'Enclosures',
+                "ordering": ("episode", "mime"),
+                "verbose_name": "Enclosure",
+                "verbose_name_plural": "Enclosures",
             },
             bases=(models.Model,),
         ),
         migrations.CreateModel(
-            name='Episode',
+            name="Episode",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('uuid', podcasting.utils.fields.UUIDField(verbose_name='ID', unique=True, max_length=36, editable=False, blank=True)),
-                ('created', models.DateTimeField(auto_now_add=True, verbose_name='created')),
-                ('updated', models.DateTimeField(auto_now=True, verbose_name='updated')),
-                ('published', models.DateTimeField(verbose_name='published', null=True, editable=False, blank=True)),
-                ('enable_comments', models.BooleanField(default=True)),
-                ('author_text', models.CharField(help_text="\n        The person or musician name(s) featured on this specific episode.\n        The suggested format is: 'email@example.com (Full Name)' but 'Full Name' only,\n        is acceptable. Multiple authors should be comma separated.", max_length=255, verbose_name='author text', blank=True)),
-                ('title', models.CharField(max_length=255, verbose_name='title')),
-                ('slug', autoslug.fields.AutoSlugField(verbose_name='slug', editable=False)),
-                ('subtitle', models.CharField(help_text='Looks best if only a few words like a tagline.', max_length=255, verbose_name='subtitle', blank=True)),
-                ('description', models.TextField(help_text="\n            This is your chance to tell potential subscribers all about your podcast.\n            Describe your subject matter, media format, episode schedule, and other\n            relevant info so that they know what they'll be getting when they\n            subscribe. In addition, make a list of the most relevant search terms\n            that you want your podcast to match, then build them into your\n            description. Note that iTunes removes podcasts that include lists of\n            irrelevant words in the itunes:summary, description, or\n            itunes:keywords tags. This field can be up to 4000 characters.", max_length=4000, verbose_name='description', blank=True)),
-                ('tracklist', models.TextField(help_text='One track per line, machine will automatically add the numbers.', verbose_name='tracklist', blank=True)),
-                ('tweet_text', models.CharField(verbose_name='tweet text', max_length=140, editable=False)),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "uuid",
+                    podcasting.utils.fields.UUIDField(
+                        verbose_name="ID",
+                        unique=True,
+                        max_length=36,
+                        editable=False,
+                        blank=True,
+                    ),
+                ),
+                (
+                    "created",
+                    models.DateTimeField(auto_now_add=True, verbose_name="created"),
+                ),
+                (
+                    "updated",
+                    models.DateTimeField(auto_now=True, verbose_name="updated"),
+                ),
+                (
+                    "published",
+                    models.DateTimeField(
+                        verbose_name="published", null=True, editable=False, blank=True
+                    ),
+                ),
+                ("enable_comments", models.BooleanField(default=True)),
+                (
+                    "author_text",
+                    models.CharField(
+                        help_text="\n        The person or musician name(s) featured on this specific episode.\n        The suggested format is: 'email@example.com (Full Name)' but 'Full Name' only,\n        is acceptable. Multiple authors should be comma separated.",
+                        max_length=255,
+                        verbose_name="author text",
+                        blank=True,
+                    ),
+                ),
+                ("title", models.CharField(max_length=255, verbose_name="title")),
+                (
+                    "slug",
+                    autoslug.fields.AutoSlugField(verbose_name="slug", editable=False),
+                ),
+                (
+                    "subtitle",
+                    models.CharField(
+                        help_text="Looks best if only a few words like a tagline.",
+                        max_length=255,
+                        verbose_name="subtitle",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "description",
+                    models.TextField(
+                        help_text="\n            This is your chance to tell potential subscribers all about your podcast.\n            Describe your subject matter, media format, episode schedule, and other\n            relevant info so that they know what they'll be getting when they\n            subscribe. In addition, make a list of the most relevant search terms\n            that you want your podcast to match, then build them into your\n            description. Note that iTunes removes podcasts that include lists of\n            irrelevant words in the itunes:summary, description, or\n            itunes:keywords tags. This field can be up to 4000 characters.",
+                        max_length=4000,
+                        verbose_name="description",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "tracklist",
+                    models.TextField(
+                        help_text="One track per line, machine will automatically add the numbers.",
+                        verbose_name="tracklist",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "tweet_text",
+                    models.CharField(
+                        verbose_name="tweet text", max_length=140, editable=False
+                    ),
+                ),
                 get_original_image_field(),
-                ('hours', models.SmallIntegerField(default=0, max_length=2, verbose_name='hours')),
-                ('minutes', models.SmallIntegerField(default=0, max_length=2, verbose_name='minutes', choices=[(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20), (21, 21), (22, 22), (23, 23), (24, 24), (25, 25), (26, 26), (27, 27), (28, 28), (29, 29), (30, 30), (31, 31), (32, 32), (33, 33), (34, 34), (35, 35), (36, 36), (37, 37), (38, 38), (39, 39), (40, 40), (41, 41), (42, 42), (43, 43), (44, 44), (45, 45), (46, 46), (47, 47), (48, 48), (49, 49), (50, 50), (51, 51), (52, 52), (53, 53), (54, 54), (55, 55), (56, 56), (57, 57), (58, 58), (59, 59)])),
-                ('seconds', models.SmallIntegerField(default=0, max_length=2, verbose_name='seconds', choices=[(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20), (21, 21), (22, 22), (23, 23), (24, 24), (25, 25), (26, 26), (27, 27), (28, 28), (29, 29), (30, 30), (31, 31), (32, 32), (33, 33), (34, 34), (35, 35), (36, 36), (37, 37), (38, 38), (39, 39), (40, 40), (41, 41), (42, 42), (43, 43), (44, 44), (45, 45), (46, 46), (47, 47), (48, 48), (49, 49), (50, 50), (51, 51), (52, 52), (53, 53), (54, 54), (55, 55), (56, 56), (57, 57), (58, 58), (59, 59)])),
-                ('keywords', models.CharField(help_text='A comma-delimited list of words for searches, up to 12; perhaps include misspellings.', max_length=255, verbose_name='keywords', blank=True)),
-                ('explicit', models.PositiveSmallIntegerField(default=1, help_text='``Clean`` will put the clean iTunes graphic by it.', verbose_name='explicit', choices=[(1, 'yes'), (2, 'no'), (3, 'clean')])),
-                ('block', models.BooleanField(default=False, help_text='Check to block this episode from iTunes because <br />its content might cause the entire show to be <br />removed from iTunes.', verbose_name='block')),
+                (
+                    "hours",
+                    models.SmallIntegerField(
+                        default=0, max_length=2, verbose_name="hours"
+                    ),
+                ),
+                (
+                    "minutes",
+                    models.SmallIntegerField(
+                        default=0,
+                        max_length=2,
+                        verbose_name="minutes",
+                        choices=[
+                            (0, 0),
+                            (1, 1),
+                            (2, 2),
+                            (3, 3),
+                            (4, 4),
+                            (5, 5),
+                            (6, 6),
+                            (7, 7),
+                            (8, 8),
+                            (9, 9),
+                            (10, 10),
+                            (11, 11),
+                            (12, 12),
+                            (13, 13),
+                            (14, 14),
+                            (15, 15),
+                            (16, 16),
+                            (17, 17),
+                            (18, 18),
+                            (19, 19),
+                            (20, 20),
+                            (21, 21),
+                            (22, 22),
+                            (23, 23),
+                            (24, 24),
+                            (25, 25),
+                            (26, 26),
+                            (27, 27),
+                            (28, 28),
+                            (29, 29),
+                            (30, 30),
+                            (31, 31),
+                            (32, 32),
+                            (33, 33),
+                            (34, 34),
+                            (35, 35),
+                            (36, 36),
+                            (37, 37),
+                            (38, 38),
+                            (39, 39),
+                            (40, 40),
+                            (41, 41),
+                            (42, 42),
+                            (43, 43),
+                            (44, 44),
+                            (45, 45),
+                            (46, 46),
+                            (47, 47),
+                            (48, 48),
+                            (49, 49),
+                            (50, 50),
+                            (51, 51),
+                            (52, 52),
+                            (53, 53),
+                            (54, 54),
+                            (55, 55),
+                            (56, 56),
+                            (57, 57),
+                            (58, 58),
+                            (59, 59),
+                        ],
+                    ),
+                ),
+                (
+                    "seconds",
+                    models.SmallIntegerField(
+                        default=0,
+                        max_length=2,
+                        verbose_name="seconds",
+                        choices=[
+                            (0, 0),
+                            (1, 1),
+                            (2, 2),
+                            (3, 3),
+                            (4, 4),
+                            (5, 5),
+                            (6, 6),
+                            (7, 7),
+                            (8, 8),
+                            (9, 9),
+                            (10, 10),
+                            (11, 11),
+                            (12, 12),
+                            (13, 13),
+                            (14, 14),
+                            (15, 15),
+                            (16, 16),
+                            (17, 17),
+                            (18, 18),
+                            (19, 19),
+                            (20, 20),
+                            (21, 21),
+                            (22, 22),
+                            (23, 23),
+                            (24, 24),
+                            (25, 25),
+                            (26, 26),
+                            (27, 27),
+                            (28, 28),
+                            (29, 29),
+                            (30, 30),
+                            (31, 31),
+                            (32, 32),
+                            (33, 33),
+                            (34, 34),
+                            (35, 35),
+                            (36, 36),
+                            (37, 37),
+                            (38, 38),
+                            (39, 39),
+                            (40, 40),
+                            (41, 41),
+                            (42, 42),
+                            (43, 43),
+                            (44, 44),
+                            (45, 45),
+                            (46, 46),
+                            (47, 47),
+                            (48, 48),
+                            (49, 49),
+                            (50, 50),
+                            (51, 51),
+                            (52, 52),
+                            (53, 53),
+                            (54, 54),
+                            (55, 55),
+                            (56, 56),
+                            (57, 57),
+                            (58, 58),
+                            (59, 59),
+                        ],
+                    ),
+                ),
+                (
+                    "keywords",
+                    models.CharField(
+                        help_text="A comma-delimited list of words for searches, up to 12; perhaps include misspellings.",
+                        max_length=255,
+                        verbose_name="keywords",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "explicit",
+                    models.PositiveSmallIntegerField(
+                        default=1,
+                        help_text="``Clean`` will put the clean iTunes graphic by it.",
+                        verbose_name="explicit",
+                        choices=[(1, "yes"), (2, "no"), (3, "clean")],
+                    ),
+                ),
+                (
+                    "block",
+                    models.BooleanField(
+                        default=False,
+                        help_text="Check to block this episode from iTunes because <br />its content might cause the entire show to be <br />removed from iTunes.",
+                        verbose_name="block",
+                    ),
+                ),
             ],
             options={
-                'ordering': ('-published', 'slug'),
-                'verbose_name': 'Episode',
-                'verbose_name_plural': 'Episodes',
+                "ordering": ("-published", "slug"),
+                "verbose_name": "Episode",
+                "verbose_name_plural": "Episodes",
             },
             bases=(models.Model,),
         ),
         migrations.CreateModel(
-            name='Show',
+            name="Show",
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('uuid', podcasting.utils.fields.UUIDField(verbose_name='id', unique=True, max_length=36, editable=False, blank=True)),
-                ('created', models.DateTimeField(auto_now_add=True, verbose_name='created')),
-                ('updated', models.DateTimeField(auto_now=True, verbose_name='updated')),
-                ('published', models.DateTimeField(verbose_name='published', null=True, editable=False, blank=True)),
-                ('ttl', models.PositiveIntegerField(default=1440, help_text='``Time to Live,`` the number of minutes a channel can be\n        cached before refreshing.', verbose_name='ttl')),
-                ('editor_email', models.EmailField(help_text="Email address of the person responsible for the feed's content.", max_length=75, verbose_name='editor email', blank=True)),
-                ('webmaster_email', models.EmailField(help_text='Email address of the person responsible for channel publishing.', max_length=75, verbose_name='webmaster email', blank=True)),
-                ('organization', models.CharField(help_text='Name of the organization, company or Web site producing the podcast.', max_length=255, verbose_name='organization')),
-                ('link', models.URLField(help_text='URL of either the main website or the\n        podcast section of the main website.', verbose_name='link')),
-                ('enable_comments', models.BooleanField(default=True)),
-                ('author_text', models.CharField(help_text="\n            This tag contains the name of the person or company that is most\n            widely attributed to publishing the Podcast and will be\n            displayed immediately underneath the title of the Podcast.\n            The suggested format is: 'email@example.com (Full Name)'\n            but 'Full Name' only, is acceptable. Multiple authors\n            should be comma separated.", max_length=255, verbose_name='author text')),
-                ('title', models.CharField(max_length=255, verbose_name='title')),
-                ('slug', autoslug.fields.AutoSlugField(verbose_name='slug', editable=False)),
-                ('subtitle', models.CharField(help_text='Looks best if only a few words, like a tagline.', max_length=255, verbose_name='subtitle')),
-                ('on_itunes', models.BooleanField(default=True, help_text='Checked if the podcast is submitted to iTunes', verbose_name='iTunes')),
-                ('description', models.TextField(help_text="\n            This is your chance to tell potential subscribers all about your\n            podcast. Describe your subject matter, media format,\n            episode schedule, and other relevant info so that they\n            know what they'll be getting when they subscribe. In\n            addition, make a list of the most relevant search terms\n            that you want yourp podcast to match, then build them into\n            your description. Note that iTunes removes podcasts that\n            include lists of irrelevant words in the itunes:summary,\n            description, or itunes:keywords tags. This field can be up\n            to 4000 characters.", max_length=4000, verbose_name='description')),
+                (
+                    "id",
+                    models.AutoField(
+                        verbose_name="ID",
+                        serialize=False,
+                        auto_created=True,
+                        primary_key=True,
+                    ),
+                ),
+                (
+                    "uuid",
+                    podcasting.utils.fields.UUIDField(
+                        verbose_name="id",
+                        unique=True,
+                        max_length=36,
+                        editable=False,
+                        blank=True,
+                    ),
+                ),
+                (
+                    "created",
+                    models.DateTimeField(auto_now_add=True, verbose_name="created"),
+                ),
+                (
+                    "updated",
+                    models.DateTimeField(auto_now=True, verbose_name="updated"),
+                ),
+                (
+                    "published",
+                    models.DateTimeField(
+                        verbose_name="published", null=True, editable=False, blank=True
+                    ),
+                ),
+                (
+                    "ttl",
+                    models.PositiveIntegerField(
+                        default=1440,
+                        help_text="``Time to Live,`` the number of minutes a channel can be\n        cached before refreshing.",
+                        verbose_name="ttl",
+                    ),
+                ),
+                (
+                    "editor_email",
+                    models.EmailField(
+                        help_text="Email address of the person responsible for the feed's content.",
+                        max_length=75,
+                        verbose_name="editor email",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "webmaster_email",
+                    models.EmailField(
+                        help_text="Email address of the person responsible for channel publishing.",
+                        max_length=75,
+                        verbose_name="webmaster email",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "organization",
+                    models.CharField(
+                        help_text="Name of the organization, company or Web site producing the podcast.",
+                        max_length=255,
+                        verbose_name="organization",
+                    ),
+                ),
+                (
+                    "link",
+                    models.URLField(
+                        help_text="URL of either the main website or the\n        podcast section of the main website.",
+                        verbose_name="link",
+                    ),
+                ),
+                ("enable_comments", models.BooleanField(default=True)),
+                (
+                    "author_text",
+                    models.CharField(
+                        help_text="\n            This tag contains the name of the person or company that is most\n            widely attributed to publishing the Podcast and will be\n            displayed immediately underneath the title of the Podcast.\n            The suggested format is: 'email@example.com (Full Name)'\n            but 'Full Name' only, is acceptable. Multiple authors\n            should be comma separated.",
+                        max_length=255,
+                        verbose_name="author text",
+                    ),
+                ),
+                ("title", models.CharField(max_length=255, verbose_name="title")),
+                (
+                    "slug",
+                    autoslug.fields.AutoSlugField(verbose_name="slug", editable=False),
+                ),
+                (
+                    "subtitle",
+                    models.CharField(
+                        help_text="Looks best if only a few words, like a tagline.",
+                        max_length=255,
+                        verbose_name="subtitle",
+                    ),
+                ),
+                (
+                    "on_itunes",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Checked if the podcast is submitted to iTunes",
+                        verbose_name="iTunes",
+                    ),
+                ),
+                (
+                    "description",
+                    models.TextField(
+                        help_text="\n            This is your chance to tell potential subscribers all about your\n            podcast. Describe your subject matter, media format,\n            episode schedule, and other relevant info so that they\n            know what they'll be getting when they subscribe. In\n            addition, make a list of the most relevant search terms\n            that you want yourp podcast to match, then build them into\n            your description. Note that iTunes removes podcasts that\n            include lists of irrelevant words in the itunes:summary,\n            description, or itunes:keywords tags. This field can be up\n            to 4000 characters.",
+                        max_length=4000,
+                        verbose_name="description",
+                    ),
+                ),
                 get_original_image_field(),
-                ('feedburner', models.URLField(help_text='Fill this out after saving this show and at least one\n            episode. URL should look like "http://feeds.feedburner.com/TitleOfShow".\n            See <a href="http://code.google.com/p/django-podcast/">documentation</a>\n            for more. <a href="http://www.feedburner.com/fb/a/ping">Manually ping</a>', verbose_name='feedburner url', blank=True)),
-                ('explicit', models.PositiveSmallIntegerField(default=1, help_text='``Clean`` will put the clean iTunes graphic by it.', verbose_name='explicit', choices=[(1, 'yes'), (2, 'no'), (3, 'clean')])),
-                ('redirect', models.URLField(help_text="The show's new URL feed if changing\n            the URL of the current show feed. Must continue old feed for at least\n            two weeks and write a 301 redirect for old feed.", verbose_name='redirect', blank=True)),
-                ('keywords', models.CharField(help_text='A comma-demlimitedlist of up to 12 words for iTunes\n            searches. Perhaps include misspellings of the title.', max_length=255, verbose_name='keywords', blank=True)),
-                ('itunes', models.URLField(help_text='Fill this out after saving this show and at least one\n            episode. URL should look like:\n            "http://phobos.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=000000000".\n            See <a href="http://code.google.com/p/django-podcast/">documentation</a> for more.', verbose_name='itunes store url', blank=True)),
-                ('twitter_tweet_prefix', models.CharField(help_text='Enter a short ``tweet_text`` prefix for new episodes on this show.', max_length=80, verbose_name='Twitter tweet prefix', blank=True)),
-                ('owner', models.ForeignKey(related_name='podcast_shows', verbose_name='owner', to=settings.AUTH_USER_MODEL, on_delete=models.PROTECT, help_text='Make certain the user account has a name and e-mail address.')),
-                ('site', models.ForeignKey(verbose_name='Site', to='sites.Site', on_delete=models.PROTECT)),
+                (
+                    "feedburner",
+                    models.URLField(
+                        help_text='Fill this out after saving this show and at least one\n            episode. URL should look like "http://feeds.feedburner.com/TitleOfShow".\n            See <a href="http://code.google.com/p/django-podcast/">documentation</a>\n            for more. <a href="http://www.feedburner.com/fb/a/ping">Manually ping</a>',
+                        verbose_name="feedburner url",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "explicit",
+                    models.PositiveSmallIntegerField(
+                        default=1,
+                        help_text="``Clean`` will put the clean iTunes graphic by it.",
+                        verbose_name="explicit",
+                        choices=[(1, "yes"), (2, "no"), (3, "clean")],
+                    ),
+                ),
+                (
+                    "redirect",
+                    models.URLField(
+                        help_text="The show's new URL feed if changing\n            the URL of the current show feed. Must continue old feed for at least\n            two weeks and write a 301 redirect for old feed.",
+                        verbose_name="redirect",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "keywords",
+                    models.CharField(
+                        help_text="A comma-demlimitedlist of up to 12 words for iTunes\n            searches. Perhaps include misspellings of the title.",
+                        max_length=255,
+                        verbose_name="keywords",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "itunes",
+                    models.URLField(
+                        help_text='Fill this out after saving this show and at least one\n            episode. URL should look like:\n            "http://phobos.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=000000000".\n            See <a href="http://code.google.com/p/django-podcast/">documentation</a> for more.',
+                        verbose_name="itunes store url",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "twitter_tweet_prefix",
+                    models.CharField(
+                        help_text="Enter a short ``tweet_text`` prefix for new episodes on this show.",
+                        max_length=80,
+                        verbose_name="Twitter tweet prefix",
+                        blank=True,
+                    ),
+                ),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        related_name="podcast_shows",
+                        verbose_name="owner",
+                        to=settings.AUTH_USER_MODEL,
+                        on_delete=models.PROTECT,
+                        help_text="Make certain the user account has a name and e-mail address.",
+                    ),
+                ),
+                (
+                    "site",
+                    models.ForeignKey(
+                        verbose_name="Site", to="sites.Site", on_delete=models.PROTECT
+                    ),
+                ),
                 get_license_field(),
             ],
             options={
-                'ordering': ('organization', 'slug'),
-                'verbose_name': 'Show',
-                'verbose_name_plural': 'Shows',
+                "ordering": ("organization", "slug"),
+                "verbose_name": "Show",
+                "verbose_name_plural": "Shows",
             },
             bases=(models.Model,),
         ),
         migrations.AddField(
-            model_name='episode',
-            name='show',
-            field=models.ForeignKey(verbose_name='Podcast', to='podcasting.Show', on_delete=models.PROTECT),
+            model_name="episode",
+            name="show",
+            field=models.ForeignKey(
+                verbose_name="Podcast", to="podcasting.Show", on_delete=models.PROTECT
+            ),
             preserve_default=True,
         ),
         migrations.AddField(
-            model_name='enclosure',
-            name='episode',
-            field=models.ForeignKey(verbose_name='episode', to='podcasting.Episode', on_delete=models.PROTECT),
+            model_name="enclosure",
+            name="episode",
+            field=models.ForeignKey(
+                verbose_name="episode",
+                to="podcasting.Episode",
+                on_delete=models.PROTECT,
+            ),
             preserve_default=True,
         ),
         migrations.AlterUniqueTogether(
-            name='enclosure',
-            unique_together=set([('episode', 'mime')]),
+            name="enclosure",
+            unique_together=set([("episode", "mime")]),
         ),
         migrations.AddField(
-            model_name='embedmedia',
-            name='episode',
-            field=models.ForeignKey(verbose_name='episode', to='podcasting.Episode', on_delete=models.PROTECT),
+            model_name="embedmedia",
+            name="episode",
+            field=models.ForeignKey(
+                verbose_name="episode",
+                to="podcasting.Episode",
+                on_delete=models.PROTECT,
+            ),
             preserve_default=True,
         ),
         migrations.AlterUniqueTogether(
-            name='embedmedia',
-            unique_together=set([('episode', 'url')]),
+            name="embedmedia",
+            unique_together=set([("episode", "url")]),
         ),
     ]

--- a/podcasting/migrations/0005_auto_20190617_1316.py
+++ b/podcasting/migrations/0005_auto_20190617_1316.py
@@ -2,33 +2,82 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
+from django.conf import settings
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('podcasting', '0004_auto_20160822_2147'),
+        ("podcasting", "0004_auto_20160822_2147"),
     ]
 
-    operations = [
-        migrations.AlterField(
-            model_name='episode',
-            name='description',
-            field=models.TextField(blank=True, help_text="\n            This is your chance to tell potential subscribers all about your podcast.\n            Describe your subject matter, media format, episode schedule, and other\n            relevant info so that they know what they'll be getting when they\n            subscribe. In addition, make a list of the most relevant search terms\n            that you want your podcast to match, then build them into your\n            description. Note that iTunes removes podcasts that include lists of\n            irrelevant words in the itunes:summary, description, or\n            itunes:keywords tags. This field can be up to 4000 plain text characters.\n            No HTML tags or styling allowed.", max_length=4000, verbose_name='description'),
-        ),
-        migrations.AlterField(
-            model_name='episode',
-            name='original_image',
-            field=models.ForeignKey(blank=True, default=None, help_text='\n                A podcast must have 1400 x 1400 pixel cover art in JPG or PNG\n                format using RGB color space. See our technical spec for\n                details. To be eligible for featuring on iTunes Stores,\n                choose an attractive, original, and square JPEG (.jpg) or\n                PNG (.png) image at a size of 1400x1400 pixels. The image\n                will be scaled down to 50x50 pixels at smallest in iTunes.\n                For reference see the <a\n                href="http://www.apple.com/itunes/podcasts/specs.html#metadata">iTunes\n                Podcast specs</a>.<br /><br /> For episode artwork to\n                display in iTunes, image must be <a\n                href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n                saved to file\'s <strong>metadata</strong></a> before\n                enclosure uploading!', null=True, on_delete=django.db.models.deletion.PROTECT, to='photologue.Photo', verbose_name='image'),
-        ),
-        migrations.AlterField(
-            model_name='show',
-            name='license',
-            field=models.CharField(help_text='To publish a podcast to iTunes it is required to set a license type.', max_length=255, verbose_name='license'),
-        ),
-        migrations.AlterField(
-            model_name='show',
-            name='original_image',
-            field=models.ForeignKey(blank=True, default=None, help_text='\n                A podcast must have 1400 x 1400 pixel cover art in JPG or PNG\n                format using RGB color space. See our technical spec for\n                details. To be eligible for featuring on iTunes Stores,\n                choose an attractive, original, and square JPEG (.jpg) or\n                PNG (.png) image at a size of 1400x1400 pixels. The image\n                will be scaled down to 50x50 pixels at smallest in iTunes.\n                For reference see the <a\n                href="http://www.apple.com/itunes/podcasts/specs.html#metadata">iTunes\n                Podcast specs</a>.<br /><br /> For episode artwork to\n                display in iTunes, image must be <a\n                href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n                saved to file\'s <strong>metadata</strong></a> before\n                enclosure uploading!', null=True, on_delete=django.db.models.deletion.SET_NULL, to='photologue.Photo', verbose_name='image'),
-        ),
-    ]
+    if "photologue" in settings.INSTALLED_APPS:
+        operations = [
+            migrations.AlterField(
+                model_name="episode",
+                name="description",
+                field=models.TextField(
+                    blank=True,
+                    help_text="\n            This is your chance to tell potential subscribers all about your podcast.\n            Describe your subject matter, media format, episode schedule, and other\n            relevant info so that they know what they'll be getting when they\n            subscribe. In addition, make a list of the most relevant search terms\n            that you want your podcast to match, then build them into your\n            description. Note that iTunes removes podcasts that include lists of\n            irrelevant words in the itunes:summary, description, or\n            itunes:keywords tags. This field can be up to 4000 plain text characters.\n            No HTML tags or styling allowed.",
+                    max_length=4000,
+                    verbose_name="description",
+                ),
+            ),
+            migrations.AlterField(
+                model_name="show",
+                name="original_image",
+                field=models.ForeignKey(
+                    blank=True,
+                    default=None,
+                    help_text='\n                A podcast must have 1400 x 1400 pixel cover art in JPG or PNG\n                format using RGB color space. See our technical spec for\n                details. To be eligible for featuring on iTunes Stores,\n                choose an attractive, original, and square JPEG (.jpg) or\n                PNG (.png) image at a size of 1400x1400 pixels. The image\n                will be scaled down to 50x50 pixels at smallest in iTunes.\n                For reference see the <a\n                href="http://www.apple.com/itunes/podcasts/specs.html#metadata">iTunes\n                Podcast specs</a>.<br /><br /> For episode artwork to\n                display in iTunes, image must be <a\n                href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n                saved to file\'s <strong>metadata</strong></a> before\n                enclosure uploading!',
+                    null=True,
+                    on_delete=django.db.models.deletion.SET_NULL,
+                    to="photologue.Photo",
+                    verbose_name="image",
+                ),
+            ),
+            migrations.AlterField(
+                model_name="show",
+                name="license",
+                field=models.CharField(
+                    help_text="To publish a podcast to iTunes it is required to set a license type.",
+                    max_length=255,
+                    verbose_name="license",
+                ),
+            ),
+            migrations.AlterField(
+                model_name="episode",
+                name="original_image",
+                field=models.ForeignKey(
+                    blank=True,
+                    default=None,
+                    help_text='\n                A podcast must have 1400 x 1400 pixel cover art in JPG or PNG\n                format using RGB color space. See our technical spec for\n                details. To be eligible for featuring on iTunes Stores,\n                choose an attractive, original, and square JPEG (.jpg) or\n                PNG (.png) image at a size of 1400x1400 pixels. The image\n                will be scaled down to 50x50 pixels at smallest in iTunes.\n                For reference see the <a\n                href="http://www.apple.com/itunes/podcasts/specs.html#metadata">iTunes\n                Podcast specs</a>.<br /><br /> For episode artwork to\n                display in iTunes, image must be <a\n                href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">\n                saved to file\'s <strong>metadata</strong></a> before\n                enclosure uploading!',
+                    null=True,
+                    on_delete=django.db.models.deletion.PROTECT,
+                    to="photologue.Photo",
+                    verbose_name="image",
+                ),
+            ),
+        ]
+    else:
+        operations = [
+            migrations.AlterField(
+                model_name="episode",
+                name="description",
+                field=models.TextField(
+                    blank=True,
+                    help_text="\n            This is your chance to tell potential subscribers all about your podcast.\n            Describe your subject matter, media format, episode schedule, and other\n            relevant info so that they know what they'll be getting when they\n            subscribe. In addition, make a list of the most relevant search terms\n            that you want your podcast to match, then build them into your\n            description. Note that iTunes removes podcasts that include lists of\n            irrelevant words in the itunes:summary, description, or\n            itunes:keywords tags. This field can be up to 4000 plain text characters.\n            No HTML tags or styling allowed.",
+                    max_length=4000,
+                    verbose_name="description",
+                ),
+            ),
+            migrations.AlterField(
+                model_name="show",
+                name="license",
+                field=models.CharField(
+                    help_text="To publish a podcast to iTunes it is required to set a license type.",
+                    max_length=255,
+                    verbose_name="license",
+                ),
+            ),
+        ]

--- a/podcasting/models.py
+++ b/podcasting/models.py
@@ -10,6 +10,7 @@ except ImportError:
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+
 try:
     from django.urls import reverse
 except ImportError:
@@ -17,7 +18,10 @@ except ImportError:
 from django.db import models
 from django.template.defaultfilters import slugify
 
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:
+    from django.utils.translation import ugettext_lazy as _
 
 from django.contrib.sites.models import Site
 
@@ -41,12 +45,14 @@ except ImportError:
 
 try:
     from easy_thumbnails.fields import ThumbnailerImageField as ImageField
+
     custom_image_field = True
 except ImportError:
     custom_image_field = False
 
 try:
     from photologue.models import Photo
+
     custom_image_field = True
 except ImportError:
     custom_image_field = False
@@ -54,6 +60,7 @@ except ImportError:
 if not custom_image_field:
     try:
         from sorl.thumbnail import ImageField  # noqa
+
         custom_image_field = True
     except ImportError:
         custom_image_field = False
@@ -65,8 +72,11 @@ if not custom_image_field:
 if "taggit" in settings.INSTALLED_APPS:
     from taggit.managers import TaggableManager
 else:
+
     def TaggableManager(blank=True):  # noqa
         return None
+
+
 try:
     import twitter
 except ImportError:
@@ -91,7 +101,10 @@ def get_episode_upload_folder(instance, pathname):
     root, ext = os.path.splitext(pathname)
     if instance.shows.count() == 1:
         return "{0}/podcasts/{1}/episodes/{2}{3}".format(
-            settings.PODCASTING_IMG_PATH, instance.shows.all()[0].slug, slugify(root), ext
+            settings.PODCASTING_IMG_PATH,
+            instance.shows.all()[0].slug,
+            slugify(root),
+            ext,
         )
     else:
         return "{0}/podcasts/episodes/{1}/{2}{3}".format(
@@ -103,6 +116,7 @@ class Show(models.Model):
     """
     A podcast show, which has many episodes.
     """
+
     EXPLICIT_CHOICES = (
         (1, _("yes")),
         (2, _("no")),
@@ -112,70 +126,109 @@ class Show(models.Model):
 
     created = models.DateTimeField(_("created"), auto_now_add=True, editable=False)
     updated = models.DateTimeField(_("updated"), auto_now=True, editable=False)
-    published = models.DateTimeField(_("published"), null=True, blank=True, editable=False)
+    published = models.DateTimeField(
+        _("published"), null=True, blank=True, editable=False
+    )
 
-    sites = models.ManyToManyField(Site, verbose_name=_('Sites'))
+    sites = models.ManyToManyField(Site, verbose_name=_("Sites"))
 
     ttl = models.PositiveIntegerField(
-        _("ttl"), default=1440,
-        help_text=_("""``Time to Live,`` the number of minutes a channel can be
-        cached before refreshing."""))
+        _("ttl"),
+        default=1440,
+        help_text=_(
+            """``Time to Live,`` the number of minutes a channel can be
+        cached before refreshing."""
+        ),
+    )
 
     owner = models.ForeignKey(
-        settings.AUTH_USER_MODEL, related_name="podcast_shows",
+        settings.AUTH_USER_MODEL,
+        related_name="podcast_shows",
         verbose_name=_("owner"),
         on_delete=models.PROTECT,
-        help_text=_("""Make certain the user account has a name and e-mail address."""))
+        help_text=_("""Make certain the user account has a name and e-mail address."""),
+    )
 
     editor_email = models.EmailField(
-        _("editor email"), blank=True,
-        help_text=_("Email address of the person responsible for the feed's content."))
+        _("editor email"),
+        blank=True,
+        help_text=_("Email address of the person responsible for the feed's content."),
+    )
     webmaster_email = models.EmailField(
-        _("webmaster email"), blank=True,
-        help_text=_("Email address of the person responsible for channel publishing."))
+        _("webmaster email"),
+        blank=True,
+        help_text=_("Email address of the person responsible for channel publishing."),
+    )
 
-    if 'licenses' in settings.INSTALLED_APPS:
+    if "licenses" in settings.INSTALLED_APPS:
         license = models.ForeignKey(License, verbose_name=_("license"))
     else:
         license = models.CharField(
-            _("license"), max_length=255,
-            help_text=_("To publish a podcast to iTunes it is required to set a license type."))
+            _("license"),
+            max_length=255,
+            help_text=_(
+                "To publish a podcast to iTunes it is required to set a license type."
+            ),
+        )
 
     organization = models.CharField(
-        _("organization"), max_length=255,
-        help_text=_("Name of the organization, company or Web site producing the podcast."))
-    link = models.URLField(_("link"), help_text=_("""URL of either the main website or the
-        podcast section of the main website."""))
+        _("organization"),
+        max_length=255,
+        help_text=_(
+            "Name of the organization, company or Web site producing the podcast."
+        ),
+    )
+    link = models.URLField(
+        _("link"),
+        help_text=_(
+            """URL of either the main website or the
+        podcast section of the main website."""
+        ),
+    )
 
     enable_comments = models.BooleanField(default=True)
 
     author_text = models.CharField(
-        _("author text"), max_length=255, help_text=_("""
+        _("author text"),
+        max_length=255,
+        help_text=_(
+            """
             This tag contains the name of the person or company that is most
             widely attributed to publishing the Podcast and will be
             displayed immediately underneath the title of the Podcast.
             The suggested format is: 'email@example.com (Full Name)'
             but 'Full Name' only, is acceptable. Multiple authors
-            should be comma separated."""))
+            should be comma separated."""
+        ),
+    )
 
     title = models.CharField(_("title"), max_length=255)
     slug = AutoSlugField(_("slug"), populate_from="title", unique="True")
 
     subtitle = models.CharField(
-        _("subtitle"), max_length=255,
-        help_text=_("Looks best if only a few words, like a tagline."))
+        _("subtitle"),
+        max_length=255,
+        help_text=_("Looks best if only a few words, like a tagline."),
+    )
 
     # If the show is not on iTunes, many fields may be ignored in your user forms
     on_itunes = models.BooleanField(
-        _("iTunes"), default=True,
-        help_text=_("Checked if the podcast is submitted to iTunes"))
+        _("iTunes"),
+        default=True,
+        help_text=_("Checked if the podcast is submitted to iTunes"),
+    )
 
     description_pretty = models.TextField(
-        _("pretty description"), blank=True,
-        help_text="May be longer than 4000 characters and contain HTML tags and styling.")
+        _("pretty description"),
+        blank=True,
+        help_text="May be longer than 4000 characters and contain HTML tags and styling.",
+    )
 
     description = models.TextField(
-        _("description"), max_length=4000, help_text=_("""
+        _("description"),
+        max_length=4000,
+        help_text=_(
+            """
             This is your chance to tell potential subscribers all about your
             podcast. Describe your subject matter, media format,
             episode schedule, and other relevant info so that they
@@ -185,12 +238,20 @@ class Show(models.Model):
             your description. Note that iTunes removes podcasts that
             include lists of irrelevant words in the itunes:summary,
             description, or itunes:keywords tags. This field can be up
-            to 4000 characters."""))
+            to 4000 characters."""
+        ),
+    )
 
-    if 'photologue' in settings.INSTALLED_APPS:
-        original_image = models.ForeignKey(Photo, verbose_name=_("image"), default=None, null=True, blank=True, 
-        on_delete=models.SET_NULL,
-        help_text=_("""
+    if "photologue" in settings.INSTALLED_APPS:
+        original_image = models.ForeignKey(
+            Photo,
+            verbose_name=_("image"),
+            default=None,
+            null=True,
+            blank=True,
+            on_delete=models.SET_NULL,
+            help_text=_(
+                """
                 A podcast must have 1400 x 1400 pixel cover art in JPG or PNG
                 format using RGB color space. See our technical spec for
                 details. To be eligible for featuring on iTunes Stores,
@@ -203,10 +264,16 @@ class Show(models.Model):
                 display in iTunes, image must be <a
                 href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">
                 saved to file's <strong>metadata</strong></a> before
-                enclosure uploading!"""))
+                enclosure uploading!"""
+            ),
+        )
     else:
         original_image = ImageField(
-            _("image"), upload_to=get_show_upload_folder, blank=True, help_text=_("""
+            _("image"),
+            upload_to=get_show_upload_folder,
+            blank=True,
+            help_text=_(
+                """
                 A podcast must have 1400 x 1400 pixel cover art in JPG or PNG
                 format using RGB color space. See our technical spec for
                 details. To be eligible for featuring on iTunes Stores,
@@ -219,59 +286,97 @@ class Show(models.Model):
                 display in iTunes, image must be <a
                 href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">
                 saved to file's <strong>metadata</strong></a> before
-                enclosure uploading!"""))
+                enclosure uploading!"""
+            ),
+        )
 
     if ResizeToFill:
-        admin_thumb_sm = ImageSpecField(source="original_image",
-                                        processors=[ResizeToFill(50, 50)],
-                                        options={"quality": 100})
-        admin_thumb_lg = ImageSpecField(source="original_image",
-                                        processors=[ResizeToFill(450, 450)],
-                                        options={"quality": 100})
-        img_show_sm = ImageSpecField(source="original_image",
-                                     processors=[ResizeToFill(120, 120)],
-                                     options={"quality": 100})
-        img_show_lg = ImageSpecField(source="original_image",
-                                     processors=[ResizeToFill(550, 550)],
-                                     options={"quality": 100})
-        img_itunes_sm = ImageSpecField(source="original_image",
-                                       processors=[ResizeToFill(144, 144)],
-                                       options={"quality": 100})
-        img_itunes_lg = ImageSpecField(source="original_image",
-                                       processors=[ResizeToFill(1400, 1400)],
-                                       options={"quality": 100})
+        admin_thumb_sm = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(50, 50)],
+            options={"quality": 100},
+        )
+        admin_thumb_lg = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(450, 450)],
+            options={"quality": 100},
+        )
+        img_show_sm = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(120, 120)],
+            options={"quality": 100},
+        )
+        img_show_lg = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(550, 550)],
+            options={"quality": 100},
+        )
+        img_itunes_sm = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(144, 144)],
+            options={"quality": 100},
+        )
+        img_itunes_lg = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(1400, 1400)],
+            options={"quality": 100},
+        )
 
     feedburner = models.URLField(
-        _("feedburner url"), blank=True,
-        help_text=_("""Fill this out after saving this show and at least one
+        _("feedburner url"),
+        blank=True,
+        help_text=_(
+            """Fill this out after saving this show and at least one
             episode. URL should look like "http://feeds.feedburner.com/TitleOfShow".
             See <a href="http://code.google.com/p/django-podcast/">documentation</a>
-            for more. <a href="http://www.feedburner.com/fb/a/ping">Manually ping</a>"""))
+            for more. <a href="http://www.feedburner.com/fb/a/ping">Manually ping</a>"""
+        ),
+    )
 
     # iTunes specific fields
     explicit = models.PositiveSmallIntegerField(
-        _("explicit"), default=1, choices=EXPLICIT_CHOICES,
-        help_text=_("``Clean`` will put the clean iTunes graphic by it."))
+        _("explicit"),
+        default=1,
+        choices=EXPLICIT_CHOICES,
+        help_text=_("``Clean`` will put the clean iTunes graphic by it."),
+    )
     redirect = models.URLField(
-        _("redirect"), blank=True,
-        help_text=_("""The show's new URL feed if changing
+        _("redirect"),
+        blank=True,
+        help_text=_(
+            """The show's new URL feed if changing
             the URL of the current show feed. Must continue old feed for at least
-            two weeks and write a 301 redirect for old feed."""))
+            two weeks and write a 301 redirect for old feed."""
+        ),
+    )
     keywords = models.CharField(
-        _("keywords"), max_length=255, blank=True,
-        help_text=_("""A comma-demlimitedlist of up to 12 words for iTunes
-            searches. Perhaps include misspellings of the title."""))
+        _("keywords"),
+        max_length=255,
+        blank=True,
+        help_text=_(
+            """A comma-demlimitedlist of up to 12 words for iTunes
+            searches. Perhaps include misspellings of the title."""
+        ),
+    )
     itunes = models.URLField(
-        _("itunes store url"), blank=True,
-        help_text=_("""Fill this out after saving this show and at least one
+        _("itunes store url"),
+        blank=True,
+        help_text=_(
+            """Fill this out after saving this show and at least one
             episode. URL should look like:
             "http://phobos.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=000000000".
-            See <a href="http://code.google.com/p/django-podcast/">documentation</a> for more."""))
+            See <a href="http://code.google.com/p/django-podcast/">documentation</a> for more."""
+        ),
+    )
 
     twitter_tweet_prefix = models.CharField(
-        _("Twitter tweet prefix"), max_length=80,
-        help_text=_("Enter a short ``tweet_text`` prefix for new episodes on this show."),
-        blank=True)
+        _("Twitter tweet prefix"),
+        max_length=80,
+        help_text=_(
+            "Enter a short ``tweet_text`` prefix for new episodes on this show."
+        ),
+        blank=True,
+    )
 
     objects = ShowQuerySet.as_manager()
     tags = TaggableManager(blank=True)
@@ -285,7 +390,9 @@ class Show(models.Model):
         return self.title
 
     def get_share_url(self):
-        return "http://{0}{1}".format(Site.objects.get_current(), self.get_absolute_url())
+        return "http://{0}{1}".format(
+            Site.objects.get_current(), self.get_absolute_url()
+        )
 
     def get_absolute_url(self):
         return reverse("podcasting_show_detail", kwargs={"slug": self.slug})
@@ -302,35 +409,54 @@ class Episode(models.Model):
     """
     An individual podcast episode and it's unique attributes.
     """
+
     SIXTY_CHOICES = tuple((x, x) for x in range(60))
     uuid = UUIDField("ID", unique=True)
 
     created = models.DateTimeField(_("created"), auto_now_add=True, editable=False)
     updated = models.DateTimeField(_("updated"), auto_now=True, editable=False)
-    published = models.DateTimeField(_("published"), null=True, blank=True, editable=False)
+    published = models.DateTimeField(
+        _("published"), null=True, blank=True, editable=False
+    )
 
     shows = models.ManyToManyField(Show, verbose_name=_("Podcasts"))
 
     enable_comments = models.BooleanField(default=True)
 
-    author_text = models.CharField(_("author text"), max_length=255, blank=True, help_text=_("""
+    author_text = models.CharField(
+        _("author text"),
+        max_length=255,
+        blank=True,
+        help_text=_(
+            """
         The person or musician name(s) featured on this specific episode.
         The suggested format is: 'email@example.com (Full Name)' but 'Full Name' only,
-        is acceptable. Multiple authors should be comma separated."""))
+        is acceptable. Multiple authors should be comma separated."""
+        ),
+    )
 
     title = models.CharField(_("title"), max_length=255)
     slug = AutoSlugField(_("slug"), populate_from="title", unique="True")
 
     subtitle = models.CharField(
-        _("subtitle"), max_length=255, blank=True,
-        help_text=_("Looks best if only a few words like a tagline."))
+        _("subtitle"),
+        max_length=255,
+        blank=True,
+        help_text=_("Looks best if only a few words like a tagline."),
+    )
 
     description_pretty = models.TextField(
-        _("pretty description"), blank=True,
-        help_text="May be longer than 4000 characters and contain HTML tags and styling.")
+        _("pretty description"),
+        blank=True,
+        help_text="May be longer than 4000 characters and contain HTML tags and styling.",
+    )
 
     description = models.TextField(
-        _("description"), max_length=4000, blank=True, help_text=_("""
+        _("description"),
+        max_length=4000,
+        blank=True,
+        help_text=_(
+            """
             This is your chance to tell potential subscribers all about your podcast.
             Describe your subject matter, media format, episode schedule, and other
             relevant info so that they know what they'll be getting when they
@@ -339,18 +465,30 @@ class Episode(models.Model):
             description. Note that iTunes removes podcasts that include lists of
             irrelevant words in the itunes:summary, description, or
             itunes:keywords tags. This field can be up to 4000 plain text characters.
-            No HTML tags or styling allowed."""))
+            No HTML tags or styling allowed."""
+        ),
+    )
 
     tracklist = models.TextField(
-        _("tracklist"), blank=True,
-        help_text=_("""One track per line, machine will automatically add the numbers."""))
+        _("tracklist"),
+        blank=True,
+        help_text=_(
+            """One track per line, machine will automatically add the numbers."""
+        ),
+    )
 
     tweet_text = models.CharField(_("tweet text"), max_length=140, editable=False)
 
-    if 'photologue' in settings.INSTALLED_APPS:
-        original_image = models.ForeignKey(Photo, verbose_name=_("image"), default=None, null=True, blank=True,
-        on_delete=models.PROTECT,
-        help_text=_("""
+    if "photologue" in settings.INSTALLED_APPS:
+        original_image = models.ForeignKey(
+            Photo,
+            verbose_name=_("image"),
+            default=None,
+            null=True,
+            blank=True,
+            on_delete=models.PROTECT,
+            help_text=_(
+                """
                 A podcast must have 1400 x 1400 pixel cover art in JPG or PNG
                 format using RGB color space. See our technical spec for
                 details. To be eligible for featuring on iTunes Stores,
@@ -363,10 +501,16 @@ class Episode(models.Model):
                 display in iTunes, image must be <a
                 href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">
                 saved to file's <strong>metadata</strong></a> before
-                enclosure uploading!"""))
+                enclosure uploading!"""
+            ),
+        )
     else:
         original_image = ImageField(
-            _("image"), upload_to=get_episode_upload_folder, blank=True, help_text=_("""
+            _("image"),
+            upload_to=get_episode_upload_folder,
+            blank=True,
+            help_text=_(
+                """
                 A podcast must have 1400 x 1400 pixel cover art in JPG or PNG
                 format using RGB color space. See our technical spec for
                 details. To be eligible for featuring on iTunes Stores,
@@ -379,43 +523,70 @@ class Episode(models.Model):
                 display in iTunes, image must be <a
                 href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">
                 saved to file's <strong>metadata</strong></a> before
-                enclosure uploading!"""))
+                enclosure uploading!"""
+            ),
+        )
 
     if ImageSpecField:
-        admin_thumb_sm = ImageSpecField(source="original_image",
-                                        processors=[ResizeToFill(50, 50)],
-                                        options={"quality": 100})
-        admin_thumb_lg = ImageSpecField(source="original_image",
-                                        processors=[ResizeToFill(450, 450)],
-                                        options={"quality": 100})
-        img_episode_sm = ImageSpecField(source="original_image",
-                                        processors=[ResizeToFill(120, 120)],
-                                        options={"quality": 100})
-        img_episode_lg = ImageSpecField(source="original_image",
-                                        processors=[ResizeToFill(550, 550)],
-                                        options={"quality": 100})
-        img_itunes_sm = ImageSpecField(source="original_image",
-                                       processors=[ResizeToFill(144, 144)],
-                                       options={"quality": 100})
-        img_itunes_lg = ImageSpecField(source="original_image",
-                                       processors=[ResizeToFill(1400, 1400)],
-                                       options={"quality": 100})
+        admin_thumb_sm = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(50, 50)],
+            options={"quality": 100},
+        )
+        admin_thumb_lg = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(450, 450)],
+            options={"quality": 100},
+        )
+        img_episode_sm = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(120, 120)],
+            options={"quality": 100},
+        )
+        img_episode_lg = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(550, 550)],
+            options={"quality": 100},
+        )
+        img_itunes_sm = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(144, 144)],
+            options={"quality": 100},
+        )
+        img_itunes_lg = ImageSpecField(
+            source="original_image",
+            processors=[ResizeToFill(1400, 1400)],
+            options={"quality": 100},
+        )
 
     # iTunes specific fields
     hours = models.SmallIntegerField(_("hours"), default=0)
     minutes = models.SmallIntegerField(_("minutes"), default=0, choices=SIXTY_CHOICES)
     seconds = models.SmallIntegerField(_("seconds"), default=0, choices=SIXTY_CHOICES)
     keywords = models.CharField(
-        _("keywords"), max_length=255, blank=True,
-        help_text=_("A comma-delimited list of words for searches, up to 12; "
-                    "perhaps include misspellings."))
+        _("keywords"),
+        max_length=255,
+        blank=True,
+        help_text=_(
+            "A comma-delimited list of words for searches, up to 12; "
+            "perhaps include misspellings."
+        ),
+    )
     explicit = models.PositiveSmallIntegerField(
-        _("explicit"), choices=Show.EXPLICIT_CHOICES,
-        help_text=_("``Clean`` will put the clean iTunes graphic by it."), default=1)
+        _("explicit"),
+        choices=Show.EXPLICIT_CHOICES,
+        help_text=_("``Clean`` will put the clean iTunes graphic by it."),
+        default=1,
+    )
     block = models.BooleanField(
-        _("block"), default=False,
-        help_text=_("Check to block this episode from iTunes because <br />its "
-                    "content might cause the entire show to be <br />removed from iTunes."""))
+        _("block"),
+        default=False,
+        help_text=_(
+            "Check to block this episode from iTunes because <br />its "
+            "content might cause the entire show to be <br />removed from iTunes."
+            ""
+        ),
+    )
 
     objects = EpisodeQuerySet.as_manager()
     tags = TaggableManager(blank=True)
@@ -429,8 +600,10 @@ class Episode(models.Model):
         return self.title
 
     def get_absolute_url(self):
-        return reverse("podcasting_episode_detail",
-                       kwargs={"show_slug": self.shows.all()[0].slug, "slug": self.slug})
+        return reverse(
+            "podcasting_episode_detail",
+            kwargs={"show_slug": self.shows.all()[0].slug, "slug": self.slug},
+        )
 
     def get_next(self):
         next = self.__class__.objects.filter(published__gt=self.published)
@@ -440,7 +613,9 @@ class Episode(models.Model):
             return False
 
     def get_prev(self):
-        prev = self.__class__.objects.filter(published__lt=self.published).order_by("-published")
+        prev = self.__class__.objects.filter(published__lt=self.published).order_by(
+            "-published"
+        )
         try:
             return prev[0]
         except IndexError:
@@ -450,11 +625,13 @@ class Episode(models.Model):
         if not self.tweet_text:
             current_site = Site.objects.get_current()
             api_url = "http://api.tr.im/api/trim_url.json"
-            u = urlopen("{0}?url=http://{1}{2}".format(
-                api_url,
-                current_site.domain,
-                self.get_absolute_url(),
-            ))
+            u = urlopen(
+                "{0}?url=http://{1}{2}".format(
+                    api_url,
+                    current_site.domain,
+                    self.get_absolute_url(),
+                )
+            )
             result = json.loads(u.read())
             self.tweet_text = "{0} {1} - {2}".format(
                 self.shows.all()[0].episode_twitter_tweet_prefix,
@@ -466,13 +643,14 @@ class Episode(models.Model):
     def tweet(self):
         if can_tweet():
             account = twitter.Api(
-                username=settings.TWITTER_USERNAME,
-                password=settings.TWITTER_PASSWORD)
+                username=settings.TWITTER_USERNAME, password=settings.TWITTER_PASSWORD
+            )
             account.PostUpdate(self.as_tweet())
         else:
             raise ImproperlyConfigured(
                 "Unable to send tweet due to either "
-                "missing python-twitter or required settings.")
+                "missing python-twitter or required settings."
+            )
 
     def seconds_total(self):
         try:
@@ -481,7 +659,9 @@ class Episode(models.Model):
             return 0
 
     def get_share_url(self):
-        return "http://{0}{1}".format(Site.objects.get_current(), self.get_absolute_url())
+        return "http://{0}{1}".format(
+            Site.objects.get_current(), self.get_absolute_url()
+        )
 
     def get_share_title(self):
         return self.title
@@ -500,6 +680,7 @@ class Enclosure(models.Model):
     """
     An enclosure is one, of possibly many, files/filetypes of an episode.
     """
+
     try:
         MIME_CHOICES = settings.PODCASTING_MIME_CHOICES
     except AttributeError:
@@ -517,37 +698,63 @@ class Enclosure(models.Model):
 
     url = models.URLField(
         _("url"),
-        help_text=_("""URL of the media file. <br /> It is <strong>very</strong>
+        help_text=_(
+            """URL of the media file. <br /> It is <strong>very</strong>
             important to remember that for episode artwork to display in iTunes, image must be
             <a href="http://answers.yahoo.com/question/index?qid=20080501164348AAjvBvQ">
             saved to file's <strong>metadata</strong></a> before enclosure uploading!<br /><br />
             For best results, choose an attractive, original, and square JPEG (.jpg) or PNG (.png)
             image at a size of 1400x1400 pixels. The image will be
-            scaled down to 50x50 pixels at smallest in iTunes."""))
+            scaled down to 50x50 pixels at smallest in iTunes."""
+        ),
+    )
 
     size = models.PositiveIntegerField(
-        _("size"), help_text=_("The length attribute is the file size in bytes. "
-                               "Find this information in the files properties "
-                               "(on a Mac, ``Get Info`` and refer to the size row)"))
+        _("size"),
+        help_text=_(
+            "The length attribute is the file size in bytes. "
+            "Find this information in the files properties "
+            "(on a Mac, ``Get Info`` and refer to the size row)"
+        ),
+    )
     mime = models.CharField(
-        _("mime format"), max_length=4, choices=MIME_CHOICES,
-        help_text=_("Supports mime types of: {0}".format(
-            ", ".join([mime[0] for mime in MIME_CHOICES]))))
+        _("mime format"),
+        max_length=4,
+        choices=MIME_CHOICES,
+        help_text=_(
+            "Supports mime types of: {0}".format(
+                ", ".join([mime[0] for mime in MIME_CHOICES])
+            )
+        ),
+    )
     bitrate = models.CharField(
-        _("bit rate"), max_length=5, default="192",
-        help_text=_("Measured in kilobits per second (kbps), often 128 or 192."))
+        _("bit rate"),
+        max_length=5,
+        default="192",
+        help_text=_("Measured in kilobits per second (kbps), often 128 or 192."),
+    )
     sample = models.CharField(
-        _("sample rate"), max_length=5, default="44.1",
-        help_text=_("Measured in kilohertz (kHz), often 44.1."))
+        _("sample rate"),
+        max_length=5,
+        default="44.1",
+        help_text=_("Measured in kilohertz (kHz), often 44.1."),
+    )
     channel = models.CharField(
-        _("channel"), max_length=1, default=2,
-        help_text=_("Number of channels; 2 for stereo, 1 for mono."))
+        _("channel"),
+        max_length=1,
+        default=2,
+        help_text=_("Number of channels; 2 for stereo, 1 for mono."),
+    )
     duration = models.IntegerField(
         _("duration"),
-        help_text=_("Duration of the audio file, in seconds (always as integer)."))
+        help_text=_("Duration of the audio file, in seconds (always as integer)."),
+    )
 
     class Meta:
-        ordering = ("url", "mime",)
+        ordering = (
+            "url",
+            "mime",
+        )
         verbose_name = _("Enclosure")
         verbose_name_plural = _("Enclosures")
 
@@ -565,7 +772,10 @@ class EmbedMedia(models.Model):
     Ideally this will be used with django-embed-video which supports
     easy embeding for YouTube and Vimeo videos and music from SoundCloud.
     """
-    episode = models.ForeignKey(Episode, verbose_name=_("episode"), on_delete=models.PROTECT)
+
+    episode = models.ForeignKey(
+        Episode, verbose_name=_("episode"), on_delete=models.PROTECT
+    )
 
     if EmbedVideoField:
         url = EmbedVideoField(_("url"), help_text=_("URL of the media file"))

--- a/podcasting/tests/urls.py
+++ b/podcasting/tests/urls.py
@@ -1,4 +1,9 @@
-from django.conf.urls import include, url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
+
+from django.conf.urls import include
 
 
 urlpatterns = [

--- a/podcasting/urls.py
+++ b/podcasting/urls.py
@@ -1,14 +1,29 @@
-from django.conf.urls import url
-from podcasting.views import ShowListView, ShowDetailView, EpisodeListView, EpisodeDetailView
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
+
+from podcasting.views import (
+    ShowListView,
+    ShowDetailView,
+    EpisodeListView,
+    EpisodeDetailView,
+)
 
 
 urlpatterns = [
-    url(r"^$", ShowListView.as_view(),
-        name="podcasting_show_list"),
-    url(r"^(?P<slug>[-\w]+)/$", ShowDetailView.as_view(),
-        name="podcasting_show_detail"),
-    url(r"^(?P<show_slug>[-\w]+)/archive/$", EpisodeListView.as_view(),
-        name="podcasting_episode_list"),
-    url(r"^(?P<show_slug>[-\w]+)/(?P<slug>[-\w]+)/$", EpisodeDetailView.as_view(),
-        name="podcasting_episode_detail"),
+    url(r"^$", ShowListView.as_view(), name="podcasting_show_list"),
+    url(
+        r"^(?P<slug>[-\w]+)/$", ShowDetailView.as_view(), name="podcasting_show_detail"
+    ),
+    url(
+        r"^(?P<show_slug>[-\w]+)/archive/$",
+        EpisodeListView.as_view(),
+        name="podcasting_episode_list",
+    ),
+    url(
+        r"^(?P<show_slug>[-\w]+)/(?P<slug>[-\w]+)/$",
+        EpisodeDetailView.as_view(),
+        name="podcasting_episode_detail",
+    ),
 ]

--- a/podcasting/urls_feeds.py
+++ b/podcasting/urls_feeds.py
@@ -1,7 +1,14 @@
-from django.conf.urls import url
+try:
+    from django.urls import re_path as url
+except ImportError:
+    from django.conf.urls import url
 
 from podcasting.feeds import (
-    RssShowFeed, AtomShowFeed, AtomRedirectView, RssRedirectView)
+    RssShowFeed,
+    AtomShowFeed,
+    AtomRedirectView,
+    RssRedirectView,
+)
 from podcasting.models import Enclosure
 
 
@@ -10,20 +17,27 @@ MIMES = "|".join([enclosure[0] for enclosure in Enclosure.MIME_CHOICES])
 
 urlpatterns = [
     # Episode list feed by show (RSS 2.0 and iTunes)
-    url(r"^(?P<show_slug>[-\w]+)/(?P<mime_type>{mimes})/rss/$".format(mimes=MIMES),
-        RssShowFeed(), name="podcasts_show_feed_rss"),
-
+    url(
+        r"^(?P<show_slug>[-\w]+)/(?P<mime_type>{mimes})/rss/$".format(mimes=MIMES),
+        RssShowFeed(),
+        name="podcasts_show_feed_rss",
+    ),
     # Episode list feed by show (Atom)
-    url(r"^(?P<show_slug>[-\w]+)/(?P<mime_type>{mimes})/atom/$".format(mimes=MIMES),
-        AtomShowFeed(), name="podcasts_show_feed_atom"),
-
+    url(
+        r"^(?P<show_slug>[-\w]+)/(?P<mime_type>{mimes})/atom/$".format(mimes=MIMES),
+        AtomShowFeed(),
+        name="podcasts_show_feed_atom",
+    ),
     # Episode list feed by show (Media RSS)
     # TODO upon request
-
     # Previously we had /itunes/ in the feed url.
     # This is now deprecated and redirects to a more general feed url.
-    url(r"^(?P<show_slug>[-\w]+)/itunes/(?P<mime_type>[-\w]+)/rss/$",
-        RssRedirectView.as_view()),
-    url(r"^(?P<show_slug>[-\w]+)/itunes/(?P<mime_type>[-\w]+)/atom/$",
-        AtomRedirectView.as_view()),
+    url(
+        r"^(?P<show_slug>[-\w]+)/itunes/(?P<mime_type>[-\w]+)/rss/$",
+        RssRedirectView.as_view(),
+    ),
+    url(
+        r"^(?P<show_slug>[-\w]+)/itunes/(?P<mime_type>[-\w]+)/atom/$",
+        AtomRedirectView.as_view(),
+    ),
 ]


### PR DESCRIPTION
In order to enable compatibility with Django 4, two specific imports
needed to be updated: gettext_lazy and url, both of which were deprecated
in Django 4.

To allow for backwards compatibility, a try/except statement has been
included which first attempts to import the Django 4 alternatives
(ugettext_lazy and re_path) and then falls back to the Django 2/3
forms if those imports are not availablity.

Additionally, I've included some logic within the most recent migration
to alleviate the errors seen in Issue 29.